### PR TITLE
Use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 16 was deprecated by Github last year, see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/